### PR TITLE
Backport ABI fix

### DIFF
--- a/recipe/0001-Fix-ABI-compatibility-1961.patch
+++ b/recipe/0001-Fix-ABI-compatibility-1961.patch
@@ -1,4 +1,4 @@
-From 4081b2fe948aec01a49cc6e231bee4e02df3d61e Mon Sep 17 00:00:00 2001
+From 93ab44afbdbc90888fea6b86b3f77c6b89573f5a Mon Sep 17 00:00:00 2001
 From: Victor Zverovich <victor.zverovich@gmail.com>
 Date: Thu, 29 Oct 2020 08:02:40 -0700
 Subject: [PATCH] Fix ABI compatibility (#1961)
@@ -10,7 +10,7 @@ Subject: [PATCH] Fix ABI compatibility (#1961)
  3 files changed, 44 insertions(+), 6 deletions(-)
 
 diff --git a/include/fmt/format-inl.h b/include/fmt/format-inl.h
-index e3b3490c..5d466eeb 100644
+index b7cb3209..d8d0bb1f 100644
 --- a/include/fmt/format-inl.h
 +++ b/include/fmt/format-inl.h
 @@ -261,11 +261,19 @@ const uint64_t basic_data<T>::powers_of_10_64[] = {
@@ -36,10 +36,10 @@ index e3b3490c..5d466eeb 100644
      10000000000000000000ULL};
  
 diff --git a/include/fmt/format.h b/include/fmt/format.h
-index 5d90f443..da121cbd 100644
+index fbe50450..c3815575 100644
 --- a/include/fmt/format.h
 +++ b/include/fmt/format.h
-@@ -868,8 +868,8 @@ template <typename T> struct FMT_EXTERN_TEMPLATE_API divtest_table_entry {
+@@ -866,8 +866,8 @@ template <typename T> struct FMT_EXTERN_TEMPLATE_API divtest_table_entry {
  // Static data is placed in this class template for the header-only config.
  template <typename T = void> struct FMT_EXTERN_TEMPLATE_API basic_data {
    static const uint64_t powers_of_10_64[];
@@ -50,7 +50,7 @@ index 5d90f443..da121cbd 100644
    static const uint64_t grisu_pow10_significands[];
    static const int16_t grisu_pow10_exponents[];
    static const divtest_table_entry<uint32_t> divtest_table_for_pow5_32[];
-@@ -893,6 +893,10 @@ template <typename T = void> struct FMT_EXTERN_TEMPLATE_API basic_data {
+@@ -891,6 +891,10 @@ template <typename T = void> struct FMT_EXTERN_TEMPLATE_API basic_data {
    static const char signs[];
    static const char left_padding_shifts[5];
    static const char right_padding_shifts[5];
@@ -61,7 +61,7 @@ index 5d90f443..da121cbd 100644
  };
  
  // Maps bsr(n) to ceil(log10(pow(2, bsr(n) + 1) - 1)).
-@@ -919,7 +923,7 @@ struct data : basic_data<> {};
+@@ -917,7 +921,7 @@ struct data : basic_data<> {};
  inline int count_digits(uint64_t n) {
    // https://github.com/fmtlib/format-benchmark/blob/master/digits10
    auto t = bsr2log10(FMT_BUILTIN_CLZLL(n | 1) ^ 63);
@@ -70,7 +70,7 @@ index 5d90f443..da121cbd 100644
  }
  #else
  // Fallback version of count_digits used when __builtin_clz is not available.
-@@ -986,7 +990,7 @@ template <> int count_digits<4>(detail::fallback_uintptr n);
+@@ -984,7 +988,7 @@ template <> int count_digits<4>(detail::fallback_uintptr n);
  // Optional version of count_digits for better performance on 32-bit platforms.
  inline int count_digits(uint32_t n) {
    auto t = bsr2log10(FMT_BUILTIN_CLZ(n | 1) ^ 31);
@@ -79,7 +79,7 @@ index 5d90f443..da121cbd 100644
  }
  #endif
  
-@@ -3787,6 +3791,7 @@ extern template void detail::vformat_to(detail::buffer<char>&, string_view,
+@@ -3786,6 +3790,7 @@ extern template void detail::vformat_to(detail::buffer<char>&, string_view,
                                          basic_format_args<format_context>,
                                          detail::locale_ref);
  namespace detail {
@@ -88,13 +88,13 @@ index 5d90f443..da121cbd 100644
  extern template FMT_API std::string grouping_impl<wchar_t>(locale_ref loc);
  extern template FMT_API char thousands_sep_impl<char>(locale_ref loc);
 diff --git a/src/format.cc b/src/format.cc
-index 88565e60..bca87b03 100644
+index 72713416..7602e643 100644
 --- a/src/format.cc
 +++ b/src/format.cc
-@@ -28,6 +28,31 @@ template dragonbox::decimal_fp<float> dragonbox::to_decimal(float x)
-     FMT_NOEXCEPT;
- template dragonbox::decimal_fp<double> dragonbox::to_decimal(double x)
-     FMT_NOEXCEPT;
+@@ -23,6 +23,31 @@ int format_float(char* buf, std::size_t size, const char* format, int precision,
+   return precision < 0 ? snprintf_ptr(buf, size, format, value)
+                        : snprintf_ptr(buf, size, format, precision, value);
+ }
 +
 +// DEPRECATED! This function exists for ABI compatibility.
 +template <typename Char>

--- a/recipe/0001-Fix-ABI-compatibility-1961.patch
+++ b/recipe/0001-Fix-ABI-compatibility-1961.patch
@@ -1,0 +1,128 @@
+From 4081b2fe948aec01a49cc6e231bee4e02df3d61e Mon Sep 17 00:00:00 2001
+From: Victor Zverovich <victor.zverovich@gmail.com>
+Date: Thu, 29 Oct 2020 08:02:40 -0700
+Subject: [PATCH] Fix ABI compatibility (#1961)
+
+---
+ include/fmt/format-inl.h | 12 ++++++++++--
+ include/fmt/format.h     | 13 +++++++++----
+ src/format.cc            | 25 +++++++++++++++++++++++++
+ 3 files changed, 44 insertions(+), 6 deletions(-)
+
+diff --git a/include/fmt/format-inl.h b/include/fmt/format-inl.h
+index e3b3490c..5d466eeb 100644
+--- a/include/fmt/format-inl.h
++++ b/include/fmt/format-inl.h
+@@ -261,11 +261,19 @@ const uint64_t basic_data<T>::powers_of_10_64[] = {
+     10000000000000000000ULL};
+ 
+ template <typename T>
+-const uint32_t basic_data<T>::zero_or_powers_of_10_32[] = {0, 0,
++const uint32_t basic_data<T>::zero_or_powers_of_10_32[] = {0,
+                                                            FMT_POWERS_OF_10(1)};
+-
+ template <typename T>
+ const uint64_t basic_data<T>::zero_or_powers_of_10_64[] = {
++    0, FMT_POWERS_OF_10(1), FMT_POWERS_OF_10(1000000000ULL),
++    10000000000000000000ULL};
++
++template <typename T>
++const uint32_t basic_data<T>::zero_or_powers_of_10_32_new[] = {
++    0, 0, FMT_POWERS_OF_10(1)};
++
++template <typename T>
++const uint64_t basic_data<T>::zero_or_powers_of_10_64_new[] = {
+     0, 0, FMT_POWERS_OF_10(1), FMT_POWERS_OF_10(1000000000ULL),
+     10000000000000000000ULL};
+ 
+diff --git a/include/fmt/format.h b/include/fmt/format.h
+index 5d90f443..da121cbd 100644
+--- a/include/fmt/format.h
++++ b/include/fmt/format.h
+@@ -868,8 +868,8 @@ template <typename T> struct FMT_EXTERN_TEMPLATE_API divtest_table_entry {
+ // Static data is placed in this class template for the header-only config.
+ template <typename T = void> struct FMT_EXTERN_TEMPLATE_API basic_data {
+   static const uint64_t powers_of_10_64[];
+-  static const uint32_t zero_or_powers_of_10_32[];
+-  static const uint64_t zero_or_powers_of_10_64[];
++  static const uint32_t zero_or_powers_of_10_32_new[];
++  static const uint64_t zero_or_powers_of_10_64_new[];
+   static const uint64_t grisu_pow10_significands[];
+   static const int16_t grisu_pow10_exponents[];
+   static const divtest_table_entry<uint32_t> divtest_table_for_pow5_32[];
+@@ -893,6 +893,10 @@ template <typename T = void> struct FMT_EXTERN_TEMPLATE_API basic_data {
+   static const char signs[];
+   static const char left_padding_shifts[5];
+   static const char right_padding_shifts[5];
++
++  // DEPRECATED! These are for ABI compatibility.
++  static const uint32_t zero_or_powers_of_10_32[];
++  static const uint64_t zero_or_powers_of_10_64[];
+ };
+ 
+ // Maps bsr(n) to ceil(log10(pow(2, bsr(n) + 1) - 1)).
+@@ -919,7 +923,7 @@ struct data : basic_data<> {};
+ inline int count_digits(uint64_t n) {
+   // https://github.com/fmtlib/format-benchmark/blob/master/digits10
+   auto t = bsr2log10(FMT_BUILTIN_CLZLL(n | 1) ^ 63);
+-  return t - (n < data::zero_or_powers_of_10_64[t]);
++  return t - (n < data::zero_or_powers_of_10_64_new[t]);
+ }
+ #else
+ // Fallback version of count_digits used when __builtin_clz is not available.
+@@ -986,7 +990,7 @@ template <> int count_digits<4>(detail::fallback_uintptr n);
+ // Optional version of count_digits for better performance on 32-bit platforms.
+ inline int count_digits(uint32_t n) {
+   auto t = bsr2log10(FMT_BUILTIN_CLZ(n | 1) ^ 31);
+-  return t - (n < data::zero_or_powers_of_10_32[t]);
++  return t - (n < data::zero_or_powers_of_10_32_new[t]);
+ }
+ #endif
+ 
+@@ -3787,6 +3791,7 @@ extern template void detail::vformat_to(detail::buffer<char>&, string_view,
+                                         basic_format_args<format_context>,
+                                         detail::locale_ref);
+ namespace detail {
++
+ extern template FMT_API std::string grouping_impl<char>(locale_ref loc);
+ extern template FMT_API std::string grouping_impl<wchar_t>(locale_ref loc);
+ extern template FMT_API char thousands_sep_impl<char>(locale_ref loc);
+diff --git a/src/format.cc b/src/format.cc
+index 88565e60..bca87b03 100644
+--- a/src/format.cc
++++ b/src/format.cc
+@@ -28,6 +28,31 @@ template dragonbox::decimal_fp<float> dragonbox::to_decimal(float x)
+     FMT_NOEXCEPT;
+ template dragonbox::decimal_fp<double> dragonbox::to_decimal(double x)
+     FMT_NOEXCEPT;
++
++// DEPRECATED! This function exists for ABI compatibility.
++template <typename Char>
++typename basic_format_context<std::back_insert_iterator<buffer<Char>>,
++                              Char>::iterator
++vformat_to(buffer<Char>& buf, basic_string_view<Char> format_str,
++           basic_format_args<basic_format_context<
++               std::back_insert_iterator<buffer<type_identity_t<Char>>>,
++               type_identity_t<Char>>>
++               args) {
++  using iterator = std::back_insert_iterator<buffer<char>>;
++  using context = basic_format_context<
++      std::back_insert_iterator<buffer<type_identity_t<Char>>>,
++      type_identity_t<Char>>;
++  auto out = iterator(buf);
++  format_handler<iterator, Char, context> h(out, format_str, args, {});
++  parse_format_string<false>(format_str, h);
++  return out;
++}
++template basic_format_context<std::back_insert_iterator<buffer<char>>,
++                              char>::iterator
++vformat_to(buffer<char>&, string_view,
++           basic_format_args<basic_format_context<
++               std::back_insert_iterator<buffer<type_identity_t<char>>>,
++               type_identity_t<char>>>);
+ }  // namespace detail
+ 
+ template struct FMT_INSTANTIATION_DEF_API detail::basic_data<void>;
+-- 
+2.29.0
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,11 @@ package:
 source:
   url: https://github.com/fmtlib/fmt/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - 0001-Fix-ABI-compatibility-1961.patch
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage('fmt', max_pin='x') }}


### PR DESCRIPTION
fmt 7.1.0 contains a breaking API change against 7.0.3. This breaks
packages that were built against version 7.*. This backports an upstream
patch that is not in a release yet that apparently reverts this ABI
change.

The upstream issue is here: https://github.com/fmtlib/fmt/issues/1961