### PR TITLE
Tighten run_export to max_pin='x.x'.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   number: 0
   skip: true  # [win and vc<14]
   run_exports:
-    - {{ pin_subpackage('fmt', max_pin='x') }}
+    - {{ pin_subpackage('fmt', max_pin='x.x.x') }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ build:
   number: 1
   skip: true  # [win and vc<14]
   run_exports:
-    - {{ pin_subpackage('fmt', max_pin='x.x.x') }}
+    - {{ pin_subpackage('fmt', max_pin='x.x') }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win and vc<14]
   run_exports:
     - {{ pin_subpackage('fmt', max_pin='x.x.x') }}


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

This PR tightens the `run_exports` of `fmt` to `max_pin='x.x'` to address issues with ABI compatibility reported on Windows. Once this is merged, it should also be backported to fmt 10.1.1. See related conversations linked below:

- https://github.com/conda-forge/fmt-feedstock/pull/39
- https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/628#issuecomment-1874717954
- https://github.com/conda-forge/conda-forge-pinning-feedstock/pull/5336
- https://github.com/mamba-org/mamba/issues/3095
- https://github.com/jaimergp/conda-pip/issues/9