### PR TITLE
Backport to fmt 10.1: Tighten run_export to max_pin='x.x'.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,10 +13,10 @@ source:
     - patches/0001-fix-core-version-10.1.1.patch
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win and vc<14]
   run_exports:
-    - {{ pin_subpackage('fmt', max_pin='x') }}
+    - {{ pin_subpackage('fmt', max_pin='x.x') }}
 
 requirements:
   build:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Backport of #40 to fmt 10.1.1. This should wait to merge until after #40 is approved and merged.

(I created a branch `fmt-10.1` and made it the target for this backport PR to avoid disrupting `main`. This is how I've seen other feedstocks handle backports in the past, please let me know if this is incorrect.)